### PR TITLE
Dashboard refactor

### DIFF
--- a/src/frontend/src/containers/DiscoverPage/DiscoverComponent.jsx
+++ b/src/frontend/src/containers/DiscoverPage/DiscoverComponent.jsx
@@ -94,21 +94,18 @@ const DiscoverComponent = ({
                       Back
                     </Button>
                     {activeStep === steps.length - 1 && (
-                      <Link
-                        style={{ textDecoration: 'none', color: 'transparent' }}
+                      <Button
+                        variant="contained"
+                        color="primary"
+                        className={classes.button}
+                        disabled={
+                          etlExecutionStatus !== ETL_STATUS_TYPE.Finished
+                        }
+                        component={Link}
                         to="/create-app"
                       >
-                        <Button
-                          variant="contained"
-                          color="primary"
-                          className={classes.button}
-                          disabled={
-                            etlExecutionStatus !== ETL_STATUS_TYPE.Finished
-                          }
-                        >
-                          Create App
-                        </Button>
-                      </Link>
+                        Create App
+                      </Button>
                     )}
                   </div>
                 </div>

--- a/src/frontend/src/containers/DiscoverPage/DiscoverInputSources/DiscoverExamplesContainer.jsx
+++ b/src/frontend/src/containers/DiscoverPage/DiscoverInputSources/DiscoverExamplesContainer.jsx
@@ -5,7 +5,7 @@ import uuid from 'uuid';
 import axios from 'axios';
 import { Log } from '@utils';
 
-const samples = [
+export const samples = [
   {
     id: uuid.v4(),
     type: 'sparqlEndpoint',

--- a/src/frontend/src/containers/HomePage/HomeComponent.jsx
+++ b/src/frontend/src/containers/HomePage/HomeComponent.jsx
@@ -6,6 +6,11 @@ import Typography from '@material-ui/core/Typography/Typography';
 import Button from '@material-ui/core/Button/Button';
 import { withStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
+import AppBar from '@material-ui/core/AppBar';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import DiscoveriesTableComponent from './children/DiscoveriesTableComponent';
+import ApplicationsTableComponent from './children/ApplicationsTableComponent';
 
 type Props = {
   classes: {
@@ -14,7 +19,13 @@ type Props = {
     button: {},
     templatesBtn: {},
     createBtn: {}
-  }
+  },
+  discoveriesList: Array<{}>,
+  applicationsList: Array<{}>
+};
+
+type State = {
+  tabIndex: number
 };
 
 const styles = theme => ({
@@ -48,52 +59,100 @@ const styles = theme => ({
   }
 });
 
-const HomeComponent = ({ classes }: Props) => (
-  <div className={classes.root}>
-    <Grid container spacing={24}>
-      <Grid item xs={4}>
-        <Paper className={classes.paper}>
-          <Typography variant="subtitle1" gutterBottom>
-            Start by creating a new application
-          </Typography>
-          <Link
-            style={{ textDecoration: 'none', color: 'transparent' }}
-            to="/discover"
-          >
-            <Button
-              variant="contained"
-              size="large"
-              className={classes.createBtn}
-            >
-              Create
-            </Button>
-          </Link>
-          <br />
-          <Button
-            variant="contained"
-            size="large"
-            className={classes.templatesBtn}
-          >
-            Templates
-          </Button>
-        </Paper>
-      </Grid>
-      <Grid item xs={8}>
-        <Paper className={classes.paper}>
-          <Typography variant="subtitle1" gutterBottom>
-            Recent applications
-          </Typography>
-        </Paper>
-      </Grid>
-      <Grid item xs={4}>
-        <Paper className={classes.paper}>
-          <Typography variant="subtitle1" gutterBottom>
-            Running discoveries
-          </Typography>
-        </Paper>
-      </Grid>
-    </Grid>
-  </div>
-);
+class HomeComponent extends React.PureComponent<Props, State> {
+  state = {
+    tabIndex: 0
+  };
+
+  handleChange = (event, tabIndex) => {
+    this.setState({ tabIndex });
+  };
+
+  render() {
+    const { classes, discoveriesList, applicationsList } = this.props;
+    const { tabIndex } = this.state;
+    return (
+      <div className={classes.root}>
+        <Grid container spacing={24}>
+          <Grid item xs={4}>
+            <Paper className={classes.paper}>
+              <Typography variant="subtitle1" gutterBottom>
+                Create a new application
+              </Typography>
+              <Link
+                style={{ textDecoration: 'none', color: 'transparent' }}
+                to="/discover"
+              >
+                <Button
+                  variant="contained"
+                  size="large"
+                  className={classes.createBtn}
+                >
+                  Create
+                </Button>
+              </Link>
+              <br />
+              <Typography variant="subtitle1" gutterBottom>
+                Or try one of predefined examples
+              </Typography>
+              <Link
+                style={{ textDecoration: 'none', color: 'transparent' }}
+                to="/discover"
+              >
+                <Button
+                  variant="contained"
+                  size="large"
+                  className={classes.templatesBtn}
+                >
+                  Treemap
+                </Button>
+              </Link>
+              <Link
+                style={{ textDecoration: 'none', color: 'transparent' }}
+                to="/discover"
+              >
+                <Button
+                  variant="contained"
+                  size="large"
+                  className={classes.templatesBtn}
+                >
+                  Google Maps
+                </Button>
+              </Link>
+              <Link
+                style={{ textDecoration: 'none', color: 'transparent' }}
+                to="/discover"
+              >
+                <Button
+                  variant="contained"
+                  size="large"
+                  className={classes.templatesBtn}
+                >
+                  Chord Diagram
+                </Button>
+              </Link>
+            </Paper>
+          </Grid>
+          <Grid item xs={8}>
+            <AppBar position="static" color="secondary">
+              <Tabs value={tabIndex} onChange={this.handleChange} centered>
+                <Tab label="Discoveries" />
+                <Tab label="My Applications" />
+              </Tabs>
+            </AppBar>
+            {tabIndex === 0 && (
+              <DiscoveriesTableComponent discoveriesList={[]} />
+            )}
+            {tabIndex === 1 && (
+              <ApplicationsTableComponent applicationsList={[]} />
+            )}
+            {/* {1 === 0 && <div>Item One</div>}
+        {2 === 1 && <div>Item Two</div>} */}
+          </Grid>
+        </Grid>
+      </div>
+    );
+  }
+}
 
 export default withStyles(styles)(HomeComponent);

--- a/src/frontend/src/containers/HomePage/HomeContainer.jsx
+++ b/src/frontend/src/containers/HomePage/HomeContainer.jsx
@@ -1,25 +1,32 @@
 import HomeComponent from './HomeComponent';
 import { connect } from 'react-redux';
 import { userActions } from '@ducks/userDuck';
-import { withWebId } from '@inrupt/solid-react-components';
+import { withWebId, withAuthorization } from '@inrupt/solid-react-components';
+import { discoverActions } from '../DiscoverPage/duck';
 
 const mapStateToProps = state => {
   return {
-    userProfile: state.user
+    userProfile: state.user,
+    discoveriesList: state.user.discoverySessions,
+    pipelinesList: state.user.pipelineExecutions,
+    applicationsList: state.user.applications
   };
 };
 
 const mapDispatchToProps = dispatch => {
+  const onInputExampleClicked = sample =>
+    dispatch(discoverActions.setSelectedInputExample(sample));
   const handleSetUserProfile = userProfile =>
     dispatch(userActions.setUserProfile(userProfile));
   return {
-    handleSetUserProfile
+    handleSetUserProfile,
+    onInputExampleClicked
   };
 };
 
-const HomeContainer = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(withWebId(HomeComponent));
-
-export default HomeContainer;
+export default withAuthorization(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(withWebId(HomeComponent))
+);

--- a/src/frontend/src/containers/HomePage/children/ApplicationsTableComponent.jsx
+++ b/src/frontend/src/containers/HomePage/children/ApplicationsTableComponent.jsx
@@ -1,0 +1,62 @@
+// @flow
+import * as React from 'react';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Paper from '@material-ui/core/Paper';
+
+type Props = {
+  applicationsList: Array<{ id: string, iri: string }>
+};
+
+let id = 0;
+function createData(name, calories, fat, carbs, protein) {
+  id += 1;
+  return { id, name, calories, fat, carbs, protein };
+}
+
+const rows = [
+  createData('Frozen yoghurt', 159, 6.0, 24, 4.0),
+  createData('Ice cream sandwich', 237, 9.0, 37, 4.3),
+  createData('Eclair', 262, 16.0, 24, 6.0),
+  createData('Cupcake', 305, 3.7, 67, 4.3),
+  createData('Gingerbread', 356, 16.0, 49, 3.9)
+];
+
+const ApplicationsTableComponent = ({ applicationsList }: Props) => (
+  <div>
+    {(applicationsList && applicationsList.length) > 0 ? (
+      <Paper>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Title</TableCell>
+              <TableCell align="right">Visualizer</TableCell>
+              <TableCell align="right">Published</TableCell>
+              <TableCell align="right">Link</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map(row => (
+              <TableRow key={row.id}>
+                <TableCell component="th" scope="row">
+                  {row.name}
+                </TableCell>
+                <TableCell align="right">{row.calories}</TableCell>
+                <TableCell align="right">{row.fat}</TableCell>
+                <TableCell align="right">{row.carbs}</TableCell>
+                <TableCell align="right">{row.protein}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+    ) : (
+      <Paper>No applications found</Paper>
+    )}
+  </div>
+);
+
+export default ApplicationsTableComponent;

--- a/src/frontend/src/containers/HomePage/children/ApplicationsTableComponent.jsx
+++ b/src/frontend/src/containers/HomePage/children/ApplicationsTableComponent.jsx
@@ -6,6 +6,7 @@ import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
 
 type Props = {
   applicationsList: Array<{ id: string, iri: string }>
@@ -32,7 +33,6 @@ const ApplicationsTableComponent = ({ applicationsList }: Props) => (
         <Table>
           <TableHead>
             <TableRow>
-              <TableCell>Title</TableCell>
               <TableCell align="right">Visualizer</TableCell>
               <TableCell align="right">Published</TableCell>
               <TableCell align="right">Link</TableCell>
@@ -46,15 +46,17 @@ const ApplicationsTableComponent = ({ applicationsList }: Props) => (
                 </TableCell>
                 <TableCell align="right">{row.calories}</TableCell>
                 <TableCell align="right">{row.fat}</TableCell>
-                <TableCell align="right">{row.carbs}</TableCell>
-                <TableCell align="right">{row.protein}</TableCell>
               </TableRow>
             ))}
           </TableBody>
         </Table>
       </Paper>
     ) : (
-      <Paper>No applications found</Paper>
+      <Paper>
+        <Typography variant="body1" gutterBottom>
+          No applications found
+        </Typography>
+      </Paper>
     )}
   </div>
 );

--- a/src/frontend/src/containers/HomePage/children/DiscoveriesTableComponent.jsx
+++ b/src/frontend/src/containers/HomePage/children/DiscoveriesTableComponent.jsx
@@ -1,0 +1,63 @@
+// @flow
+import * as React from 'react';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Paper from '@material-ui/core/Paper';
+
+type Props = {
+  discoveriesList: Array<{ id: string, iri: string }>
+};
+
+let id = 0;
+function createData(name, calories, fat, carbs, protein) {
+  id += 1;
+  return { id, name, calories, fat, carbs, protein };
+}
+
+const rows = [
+  createData('Frozen yoghurt', 159, 6.0, 24, 4.0),
+  createData('Ice cream sandwich', 237, 9.0, 37, 4.3),
+  createData('Eclair', 262, 16.0, 24, 6.0),
+  createData('Cupcake', 305, 3.7, 67, 4.3),
+  createData('Gingerbread', 356, 16.0, 49, 3.9)
+];
+
+const DiscoveriesTableComponent = ({ discoveriesList }: Props) => (
+  <div>
+    {discoveriesList && discoveriesList.length > 0 ? (
+      <Paper>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Discovery ID</TableCell>
+              <TableCell align="right">Status</TableCell>
+              <TableCell align="right">Fat (g)</TableCell>
+              <TableCell align="right">Carbs (g)</TableCell>
+              <TableCell align="right">Protein (g)</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map(row => (
+              <TableRow key={row.id}>
+                <TableCell component="th" scope="row">
+                  {row.name}
+                </TableCell>
+                <TableCell align="right">{row.calories}</TableCell>
+                <TableCell align="right">{row.fat}</TableCell>
+                <TableCell align="right">{row.carbs}</TableCell>
+                <TableCell align="right">{row.protein}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+    ) : (
+      <Paper>No discoveries found</Paper>
+    )}
+  </div>
+);
+
+export default DiscoveriesTableComponent;

--- a/src/frontend/src/containers/HomePage/children/DiscoveriesTableComponent.jsx
+++ b/src/frontend/src/containers/HomePage/children/DiscoveriesTableComponent.jsx
@@ -6,24 +6,11 @@ import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
 
 type Props = {
-  discoveriesList: Array<{ id: string, iri: string }>
+  discoveriesList: Array<{ id: string, finished: boolean }>
 };
-
-let id = 0;
-function createData(name, calories, fat, carbs, protein) {
-  id += 1;
-  return { id, name, calories, fat, carbs, protein };
-}
-
-const rows = [
-  createData('Frozen yoghurt', 159, 6.0, 24, 4.0),
-  createData('Ice cream sandwich', 237, 9.0, 37, 4.3),
-  createData('Eclair', 262, 16.0, 24, 6.0),
-  createData('Cupcake', 305, 3.7, 67, 4.3),
-  createData('Gingerbread', 356, 16.0, 49, 3.9)
-];
 
 const DiscoveriesTableComponent = ({ discoveriesList }: Props) => (
   <div>
@@ -32,30 +19,28 @@ const DiscoveriesTableComponent = ({ discoveriesList }: Props) => (
         <Table>
           <TableHead>
             <TableRow>
-              <TableCell>Discovery ID</TableCell>
-              <TableCell align="right">Status</TableCell>
-              <TableCell align="right">Fat (g)</TableCell>
-              <TableCell align="right">Carbs (g)</TableCell>
-              <TableCell align="right">Protein (g)</TableCell>
+              <TableCell align="left">Discovery ID</TableCell>
+              <TableCell align="left">Status</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
-            {rows.map(row => (
-              <TableRow key={row.id}>
-                <TableCell component="th" scope="row">
-                  {row.name}
+            {discoveriesList.map(discovery => (
+              <TableRow key={discovery.id}>
+                <TableCell align="left">{discovery.id}</TableCell>
+                <TableCell align="left">
+                  {discovery.finished ? 'Finished' : 'In progress'}
                 </TableCell>
-                <TableCell align="right">{row.calories}</TableCell>
-                <TableCell align="right">{row.fat}</TableCell>
-                <TableCell align="right">{row.carbs}</TableCell>
-                <TableCell align="right">{row.protein}</TableCell>
               </TableRow>
             ))}
           </TableBody>
         </Table>
       </Paper>
     ) : (
-      <Paper>No discoveries found</Paper>
+      <Paper>
+        <Typography variant="body1" gutterBottom>
+          No discoveries found
+        </Typography>
+      </Paper>
     )}
   </div>
 );

--- a/src/frontend/src/containers/HomePage/children/PipelinesTableComponent.jsx
+++ b/src/frontend/src/containers/HomePage/children/PipelinesTableComponent.jsx
@@ -1,0 +1,61 @@
+// @flow
+import * as React from 'react';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Paper from '@material-ui/core/Paper';
+import { ETL_STATUS_MAP } from '@utils';
+import Typography from '@material-ui/core/Typography';
+
+type Props = {
+  pipelinesList: Array<{
+    executionIri: string,
+    selectedVisualiser: string,
+    status: { '@id'?: string, status?: string },
+    webId: string
+  }>
+};
+
+const PipelinesTableComponent = ({ pipelinesList }: Props) => (
+  <div>
+    {(pipelinesList && pipelinesList.length) > 0 ? (
+      <Paper>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell align="left"> Execution IRI </TableCell>
+              <TableCell align="left"> Visualizer </TableCell>
+              <TableCell align="left"> Status </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {pipelinesList.map(pipeline => (
+              <TableRow key={pipeline.executionIri}>
+                <TableCell align="left">{pipeline.executionIri}</TableCell>
+                <TableCell align="left">
+                  {pipeline.selectedVisualiser}
+                </TableCell>
+                <TableCell align="left">
+                  {(pipeline.status &&
+                    ETL_STATUS_MAP[pipeline.status['@id']]) ||
+                    (pipeline.status && pipeline.status.status) ||
+                    'N/A'}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+    ) : (
+      <Paper>
+        <Typography variant="body1" gutterBottom>
+          No pipelines found
+        </Typography>
+      </Paper>
+    )}
+  </div>
+);
+
+export default PipelinesTableComponent;


### PR DESCRIPTION
- Examples in the main dashboard, redirecting to /discover with appropriate sample selected
- Fixed issue with "Create app" button that was clickable even if disabled
- Basic tables showing pipelines and discoveries, both running and finished. There is also tab for applications but no logic implemented there yet.

Things still missing to be done:
- Add sockets so statuses update accordingly in the dashboard
- Add buttons so users can resume activity once a discovery/pipeline was finished/executed
- Add applications there, with a button that will open it