### PR TITLE
[Backend] Stop on delete

### DIFF
--- a/src/backend/src/main/java/com/linkedpipes/lpa/backend/controllers/DataSourceController.java
+++ b/src/backend/src/main/java/com/linkedpipes/lpa/backend/controllers/DataSourceController.java
@@ -30,6 +30,14 @@ public class DataSourceController {
     @NotNull
     private final TriFunction<String, String, List<String>, ResponseEntity<String>> memoizedGetTemplateDescription = memoize(this::doGetTemplateDescription);
 
+    /**
+     * Returns a data source template description readable by Discovery.
+     *
+     * @param sparqlEndpointIri the desired endpoint IRI for the default SPARQL service described in the output
+     * @param dataSampleIri     the IRI of the data sample describing the data in the data source
+     * @param namedGraphs       the named graphs specified for the SPARQL endpoint
+     * @return a data source template
+     */
     @GetMapping(TEMPLATE_DESCRIPTION_PATH)
     public ResponseEntity<String> getTemplateDescription(@NotNull @RequestParam(SPARQL_ENDPOINT_IRI_PARAM) String sparqlEndpointIri,
                                                          @NotNull @RequestParam(DATA_SAMPLE_IRI_PARAM) String dataSampleIri,

--- a/src/backend/src/main/java/com/linkedpipes/lpa/backend/controllers/UserController.java
+++ b/src/backend/src/main/java/com/linkedpipes/lpa/backend/controllers/UserController.java
@@ -62,10 +62,15 @@ public class UserController {
 
     /**
      * Delete execution from user profile in DB. If user is not found, 404 is
-     * returned. Execution is cancelled first what might trigger several status
-     * messages on sockets.
+     * returned.
      *
-     * Sockets:: room: [webId], event: executionDeleted, message: ExecutionDeleted.
+     * Successful deletion is annnounced via sockets:
+     * - room: webId
+     * - event name: executionDeleted
+     * - message type: ExecutionDeleted.
+     *
+     * Execution is cancelled first what might trigger several additional status
+     * messages on sockets.
      *
      * @param user user identifier - currently webId is sent from frontend
      * @param executionIri IRI of execution to be deleted
@@ -99,11 +104,15 @@ public class UserController {
 
     /**
      * Delete discovery from user profile in DB. If user is not found, 404 is
-     * returned. On successful change, deletion is annnounced via sockets.
-     * Discovery is cancelled first what might trigger several status messages
-     * on sockets.
+     * returned.
      *
-     * Sockets:: room: [webId], event: discoveryDeleted, message: DiscoveryDeleted.
+     * On successful change, deletion is annnounced via sockets:
+     * - room: webId,
+     * - event name: discoveryDeleted
+     * - message type: DiscoveryDeleted
+     *
+     * Discovery is cancelled first what might trigger several additioinal
+     * status messages on sockets.
      *
      * @param user user identifier - currently webId is sent from frontend
      * @param discoveryId ID of discovery to be deleted
@@ -136,9 +145,12 @@ public class UserController {
 
     /**
      * Set color scheme on user profile. If user doesn't exist, it will be added
-     * automatically. On successful change, new color is annnounced via sockets.
+     * automatically.
      *
-     * Sockets:: room: [webId], event: colorChanged, message: color as string.
+     * On successful change, new color is annnounced via sockets:
+     * - room: webId
+     * - event name: colorChanged
+     * - message: color as string.
      *
      * @param user user identifier - currently webId is sent from frontend
      * @param color new color (arbitrary string up to 255 characters)

--- a/src/backend/src/main/java/com/linkedpipes/lpa/backend/controllers/VirtuosoController.java
+++ b/src/backend/src/main/java/com/linkedpipes/lpa/backend/controllers/VirtuosoController.java
@@ -17,8 +17,8 @@ public class VirtuosoController {
 
     /**
      * Get service description of our virtuoso SPARQL endpoint
-     * @param graphId
-     * @return
+     * @param graphId application specific graph identifier (full graph name IRI will be generated out of it)
+     * @return Service description (Turtle)
      */
     @GetMapping(SERVICE_DESCRIPTION_PATH)
     public ResponseEntity<String> serviceDescription(@RequestParam(value = "graphId") String graphId) {
@@ -28,7 +28,7 @@ public class VirtuosoController {
     /**
      * Check if a named graph exists in our Virtuoso db
      * @param graphName - full URI identifying the named graph
-     * @return
+     * @return 200 OK if graph exists or 404 otherwise
      * @throws LpAppsException
      */
     @GetMapping("api/virtuoso/graphExists")

--- a/src/backend/src/main/java/com/linkedpipes/lpa/backend/services/ExecutorService.java
+++ b/src/backend/src/main/java/com/linkedpipes/lpa/backend/services/ExecutorService.java
@@ -13,5 +13,6 @@ public interface ExecutorService {
     Discovery startDiscoveryFromInput(String discoveryConfig, String userId, String sparqlEndpointIri, String dataSampleIri, List<String> namedGraphs) throws LpAppsException, UserNotFoundException;
     Discovery startDiscoveryFromInputIri(String discoveryConfigIri, String userId) throws LpAppsException, UserNotFoundException;
     Execution executePipeline(String etlPipelineIri, String userId, String selectedVisualiser) throws LpAppsException, UserNotFoundException;
-
+    void cancelExecution(String executionIri);
+    void cancelDiscovery(String discoveryId);
 }


### PR DESCRIPTION
This will cancel running executions and possibly also discoveries when delete endpoint is called.
Polling stops in the next iteration.

Also some javadoc is added here and there.